### PR TITLE
Execute subscription actions synchronously

### DIFF
--- a/Sources/ReactiveStreams/stream.swift
+++ b/Sources/ReactiveStreams/stream.swift
@@ -198,8 +198,8 @@ open class EventStream<Value>: Publisher
   {
     let subscription = Subscription(source: self)
 
-    func processSubscription()
-    {
+    queue.sync {
+      begun.store(true, .relaxed)
       subscriptionHandler(subscription)
       if !completed
       {
@@ -209,19 +209,6 @@ open class EventStream<Value>: Publisher
       {
         notificationHandler(Event(error: StreamError.subscriptionFailed))
       }
-    }
-
-    if !started
-    { // the queue isn't running yet, no observers
-      queue.sync {
-        begun.store(true, .relaxed)
-        processSubscription()
-      }
-      return
-    }
-
-    queue.async {
-      processSubscription()
     }
   }
 

--- a/Sources/ReactiveStreams/stream.swift
+++ b/Sources/ReactiveStreams/stream.swift
@@ -198,6 +198,16 @@ open class EventStream<Value>: Publisher
   {
     let subscription = Subscription(source: self)
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    if #available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)
+    {
+      if started
+      {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+      }
+    }
+#endif
+
     queue.sync {
       begun.store(true, .relaxed)
       subscriptionHandler(subscription)

--- a/Sources/ReactiveStreams/subscription.swift
+++ b/Sources/ReactiveStreams/subscription.swift
@@ -27,7 +27,7 @@ final public class Subscription
   func shouldNotify() -> Bool
   {
     var p: Int64 = 1
-    while requested.loadCAS(&p, p-1, .weak, .relaxed, .relaxed)
+    while !requested.loadCAS(&p, p-1, .weak, .relaxed, .relaxed)
     {
       if p == Int64.max { break }
       if p <= 0 { return false }


### PR DESCRIPTION
This makes it such that subscription actions have completed by the time their corresponding call returns. This does mean that a producer that has multiple observers should not use the main queue as its DispatchQueue -- a restriction that doesn't seem like a problem.