### PR TITLE
add merge as a method on EventStream

### DIFF
--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -134,3 +134,18 @@ extension EventStream
     return flatMap(MergeStream(queue), transform: transform)
   }
 }
+
+extension EventStream
+{
+  public func merge(with other: EventStream<Value>) -> EventStream<Value>
+  {
+    let merged = MergeStream<Value>(qos: self.queue.qos)
+
+    merged.queue.async {
+      merged.performMerge(self)
+      merged.performMerge(other)
+    }
+
+    return merged
+  }
+}

--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -10,11 +10,19 @@ import Dispatch
 
 public class MergeStream<Value>: SubStream<Value, Value>
 {
-  private var sources = Set<Subscription>()
-  private var closed = false
+  fileprivate var sources = Set<Subscription>()
+  fileprivate var closed = false
+  fileprivate let closeAfterLastSourceCloses: Bool
 
   override init(validated: ValidatedQueue)
   {
+    closeAfterLastSourceCloses = true
+    super.init(validated: validated)
+  }
+
+  fileprivate init(validated: ValidatedQueue, flatMap: Bool = false)
+  {
+    closeAfterLastSourceCloses = !flatMap
     super.init(validated: validated)
   }
 
@@ -47,7 +55,7 @@ public class MergeStream<Value>: SubStream<Value, Value>
             merged.sources.remove(subscription)
             if event.final != nil
             { // merged stream completed normally
-              if merged.closed && merged.sources.isEmpty
+              if (merged.closeAfterLastSourceCloses || merged.closed), merged.sources.isEmpty
               { // no other event is forthcoming from any stream
                 merged.dispatch(Event.streamCompleted)
               }
@@ -75,12 +83,10 @@ public class MergeStream<Value>: SubStream<Value, Value>
 
   public override func close()
   {
+    guard !completed else { return }
     queue.async {
       self.closed = true
-      if self.sources.isEmpty
-      {
-        self.dispatch(Event.streamCompleted)
-      }
+      self.dispatch(Event.streamCompleted)
     }
   }
 
@@ -99,9 +105,38 @@ public class MergeStream<Value>: SubStream<Value, Value>
   }
 }
 
+internal class FlatMapStream<Value>: MergeStream<Value>
+{
+  convenience init(qos: DispatchQoS = DispatchQoS.current)
+  {
+    self.init(validated: ValidatedQueue(label: "eventstream", qos: qos))
+  }
+
+  convenience init(_ queue: DispatchQueue)
+  {
+    self.init(validated: ValidatedQueue(label: "eventstream", target: queue))
+  }
+
+  override init(validated: ValidatedQueue)
+  {
+    super.init(validated: validated, flatMap: true)
+  }
+
+  public override func close()
+  {
+    queue.async {
+      self.closed = true
+      if self.sources.isEmpty
+      {
+        self.dispatch(Event.streamCompleted)
+      }
+    }
+  }
+}
+
 extension EventStream
 {
-  private func flatMap<U>(_ stream: MergeStream<U>, transform: @escaping (Value) -> EventStream<U>) -> EventStream<U>
+  private func flatMap<U>(_ stream: FlatMapStream<U>, transform: @escaping (Value) -> EventStream<U>) -> EventStream<U>
   {
     self.subscribe(
       subscriber: stream,
@@ -126,12 +161,12 @@ extension EventStream
 
   public func flatMap<U>(qos: DispatchQoS? = nil, transform: @escaping (Value) -> EventStream<U>) -> EventStream<U>
   {
-    return flatMap(MergeStream(qos: qos ?? self.qos), transform: transform)
+    return flatMap(FlatMapStream(qos: qos ?? self.qos), transform: transform)
   }
 
   public func flatMap<U>(_ queue: DispatchQueue, transform: @escaping (Value) -> EventStream<U>) -> EventStream<U>
   {
-    return flatMap(MergeStream(queue), transform: transform)
+    return flatMap(FlatMapStream(queue), transform: transform)
   }
 }
 

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -28,7 +28,6 @@ extension mergeTests {
         ("testMerge5", testMerge5),
         ("testMerge6", testMerge6),
         ("testMerge7", testMerge7),
-        ("testMerge8", testMerge8),
     ]
 }
 

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -28,6 +28,7 @@ extension mergeTests {
         ("testMerge5", testMerge5),
         ("testMerge6", testMerge6),
         ("testMerge7", testMerge7),
+        ("testMerge8", testMerge8),
     ]
 }
 

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -632,18 +632,15 @@ class streamTests: XCTestCase
     let merged = MergeStream<Int>()
     split.forEach(merged.merge)
 
-    merged.countEvents().onValue {
-      count in
-      if count == splits*events { e.fulfill() }
-      else { print(count) }
-    }
+    merged.countEvents().onValue { XCTAssert($0 == splits*events) }
+    stream.onCompletion { e.fulfill() }
 
-    XCTAssert(stream.requested == .max, "stream.requested has an unexpected value; probable race condition")
+    XCTAssert(stream.requested == .max)
     for i in 0..<events { stream.post(i+1) }
     stream.close()
-    merged.close()
 
     waitForExpectations(timeout: 1.0, handler: nil)
+    merged.close()
   }
 
   func testSplit3()


### PR DESCRIPTION
-- also make sure that a merged stream ends when its last source completes
-- this is different from a flatMap stream; a flatMap stream ends when its input stream is completed and every individual stream it has received from its source is complete as well
-- in either case, the first error encountered ends the stream, as expected