### PR TITLE
add an option to delay error reporting during merging

### DIFF
--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -29,6 +29,8 @@ extension mergeTests {
         ("testMerge6", testMerge6),
         ("testMerge7", testMerge7),
         ("testMerge8", testMerge8),
+        ("testMergeDelayingError1", testMergeDelayingError1),
+        ("testMergeDelayingError2", testMergeDelayingError2),
     ]
 }
 


### PR DESCRIPTION
use it by setting the optional parameter `delayingErrors` to `true`