### PR TITLE
add filtering operations to EventStream

### DIFF
--- a/Sources/ReactiveStreams/stream-filter.swift
+++ b/Sources/ReactiveStreams/stream-filter.swift
@@ -1,0 +1,82 @@
+//
+//  stream-filter.swift
+//  ReactiveStreams
+//
+//  Created by Guillaume Lessard on 9/25/18.
+//  Copyright © 2018 Guillaume Lessard. All rights reserved.
+//
+
+import Dispatch
+
+extension EventStream
+{
+  private func compactMap<U>(_ stream: SubStream<Value, U>, transform: @escaping (Value) throws -> U?) -> EventStream<U>
+  {
+    self.subscribe(
+      substream: stream,
+      notificationHandler: {
+        mapped, event in
+        mapped.queue.async {
+          do {
+            if let transformed = try transform(event.get())
+            {
+              mapped.dispatch(Event(value: transformed))
+            }
+            else
+            {
+              mapped.request(1)
+            }
+          }
+          catch {
+            mapped.dispatch(Event(error: error))
+          }
+        }
+      }
+    )
+    return stream
+  }
+
+  public func compactMap<U>(qos: DispatchQoS? = nil, transform: @escaping (Value) throws -> U?) -> EventStream<U>
+  {
+    return compactMap(SubStream(qos: qos ?? self.qos), transform: transform)
+  }
+
+  public func compactMap<U>(_ queue: DispatchQueue, transform: @escaping (Value) throws -> U?) -> EventStream<U>
+  {
+    return compactMap(SubStream(queue), transform: transform)
+  }
+}
+
+extension EventStream
+{
+  public func filter(qos: DispatchQoS? = nil, predicate: @escaping (Value) throws -> Bool) -> EventStream<Value>
+  {
+    return compactMap(qos: qos, transform: { try predicate($0) ? $0 : nil })
+  }
+
+  public func filter(_ queue: DispatchQueue, predicate: @escaping (Value) throws -> Bool) -> EventStream<Value>
+  {
+    return compactMap(queue, transform: { try predicate($0) ? $0 : nil })
+  }
+}
+
+extension EventStream
+{
+  public func compacted<U>() -> EventStream<U>
+    where Value == Optional<U>
+  {
+    return compacted(self.queue)
+  }
+
+  public func compacted<U>(qos: DispatchQoS) -> EventStream<U>
+    where Value == Optional<U>
+  {
+    return compactMap(qos: qos, transform: { $0 })
+  }
+
+  public func compacted<U>(_ queue: DispatchQueue) -> EventStream<U>
+    where Value == Optional<U>
+  {
+    return compactMap(queue, transform: { $0 })
+  }
+}

--- a/Sources/ReactiveStreams/stream-substream.swift
+++ b/Sources/ReactiveStreams/stream-substream.swift
@@ -45,4 +45,9 @@ open class SubStream<InputValue, OutputValue>: EventStream<OutputValue>
     }
     return additional
   }
+
+  func request(_ additional: Int64)
+  {
+    subscription?.request(additional)
+  }
 }

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -44,7 +44,10 @@ extension onRequestTests {
 extension streamTests {
     static let __allTests = [
         ("testCoalesce", testCoalesce),
+        ("testCompacted", testCompacted),
+        ("testCompactMap", testCompactMap),
         ("testCountEvents", testCountEvents),
+        ("testFilter", testFilter),
         ("testFinal1", testFinal1),
         ("testFinal2", testFinal2),
         ("testFinal3", testFinal3),

--- a/Xcode/stream.xcodeproj/project.pbxproj
+++ b/Xcode/stream.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		031C42701CFE666600F4B44B /* stream-split.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031C426F1CFE666600F4B44B /* stream-split.swift */; };
 		031CFBB91CEFB6CD00F4B44B /* stream-onrequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CFBB81CEFB6CD00F4B44B /* stream-onrequest.swift */; };
 		031CFBBB1CEFD6B100F4B44B /* onRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CFBBA1CEFD6B100F4B44B /* onRequestTests.swift */; };
+		035C016D215AFBA900F4B44B /* stream-filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C016C215AFBA900F4B44B /* stream-filter.swift */; };
 		035FF5822155E94900F4B44B /* Outcome.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 035FF57F2155D05600F4B44B /* Outcome.framework */; };
 		036941D520EC4E5600F4B44B /* stream-timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036941D420EC4E5600F4B44B /* stream-timer.swift */; };
 		036941DD20EC5BDC00F4B44B /* timerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036941DB20EC586B00F4B44B /* timerTests.swift */; };
@@ -125,6 +126,7 @@
 		031C426F1CFE666600F4B44B /* stream-split.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "stream-split.swift"; sourceTree = "<group>"; };
 		031CFBB81CEFB6CD00F4B44B /* stream-onrequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "stream-onrequest.swift"; sourceTree = "<group>"; };
 		031CFBBA1CEFD6B100F4B44B /* onRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = onRequestTests.swift; path = ../../Tests/ReactiveStreamsTests/onRequestTests.swift; sourceTree = "<group>"; };
+		035C016C215AFBA900F4B44B /* stream-filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "stream-filter.swift"; sourceTree = "<group>"; };
 		035FF5792155D05600F4B44B /* Outcome.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Outcome.xcodeproj; path = dependencies/outcome/Xcode/Outcome.xcodeproj; sourceTree = "<group>"; };
 		036941D420EC4E5600F4B44B /* stream-timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "stream-timer.swift"; sourceTree = "<group>"; };
 		036941DB20EC586B00F4B44B /* timerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = timerTests.swift; path = ../../Tests/ReactiveStreamsTests/timerTests.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				031C426F1CFE666600F4B44B /* stream-split.swift */,
 				03A0D5BE1EB15ED000F4B44B /* stream-paused.swift */,
 				03FD4DAC21581BFC00F4B44B /* stream-final.swift */,
+				035C016C215AFBA900F4B44B /* stream-filter.swift */,
 			);
 			name = "stream operations";
 			sourceTree = "<group>";
@@ -522,6 +525,7 @@
 				03FE12DD1EA8802800F4B44B /* dispatch-utilities.swift in Sources */,
 				03A0D5BF1EB15ED000F4B44B /* stream-paused.swift in Sources */,
 				03A0D5C11EB31C0600F4B44B /* stream-limited.swift in Sources */,
+				035C016D215AFBA900F4B44B /* stream-filter.swift in Sources */,
 				03D89FBE1CD46B4300F4B44B /* stream.swift in Sources */,
 				031C42651CFE4B9B00F4B44B /* stream-post.swift in Sources */,
 				038EB3A51CDD35EC00F4B44B /* stream-merge.swift in Sources */,


### PR DESCRIPTION
- compactMap is the more general operation, like Sequence.compactMap
- compacted unwraps Optionals while stripping nils
- filter keeps or rejects items based on a predicate