### PR TITLE
treat .max differently

### DIFF
--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -126,8 +126,9 @@ public class MergeStream<Value>: SubStream<Value>
   public override func updateRequest(_ requested: Int64) -> Int64
   {
     let additional = super.updateRequest(requested)
-    // copy sources so that a modification in the main queue doesn't interfere.
-    // (optimistic? should this use dispatch_barrier_async instead?)
+    // copy set of subscriptions so that a modification on the main queue
+    // will not interfere. (is this too optimistic? should this use
+    // dispatch_barrier_async instead? (or a lock?))
     let s = subscriptions
     for subscription in s
     {

--- a/Sources/ReactiveStreams/stream-onrequest.swift
+++ b/Sources/ReactiveStreams/stream-onrequest.swift
@@ -54,10 +54,12 @@ open class OnRequestStream: EventStream<Int>
 
   open func start()
   {
-    if started.CAS(false, true, .strong, .relaxed)
-    {
-      processNext()
-    }
+    var streaming = started.load(.relaxed)
+    repeat {
+      if streaming { return }
+    } while !started.loadCAS(&streaming, true, .weak, .relaxed, .relaxed)
+
+    processNext()
   }
 
   @discardableResult

--- a/Sources/ReactiveStreams/stream-paused.swift
+++ b/Sources/ReactiveStreams/stream-paused.swift
@@ -45,11 +45,13 @@ open class Paused<Value>: SubStream<Value>
 
   open func start()
   {
-    if started.CAS(false, true, .strong, .relaxed)
-    {
-      let request = torequest.swap(0, .relaxed)
-      if request > 0 { super.updateRequest(request) }
-    }
+    var streaming = started.load(.relaxed)
+    repeat {
+      if streaming { return }
+    } while !started.loadCAS(&streaming, true, .weak, .relaxed, .relaxed)
+
+    let request = torequest.swap(0, .relaxed)
+    if request > 0 { super.updateRequest(request) }
   }
 }
 

--- a/Sources/ReactiveStreams/stream.swift
+++ b/Sources/ReactiveStreams/stream.swift
@@ -248,6 +248,8 @@ open class EventStream<Value>: Publisher
       if prev >= requested || prev == .min { return 0 }
     } while !pending.loadCAS(&prev, requested, .weak, .relaxed, .relaxed)
 
+    if requested == .max { return .max }
+
     return (requested-prev)
   }
 

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -808,8 +808,8 @@ class streamTests: XCTestCase
     XCTAssertEqual(stream.requested, 0)
     XCTAssertEqual(paused.requested, 0)
 
-    let signaler = stream.next(count: 5).map(q, transform: { s -> Void in s.signal() })
-    signaler.onValue {}
+    let signaler = stream.next(count: 5)
+    signaler.onValue(q) { $0.signal() }
     q.sync {}
 
     postAndWait()
@@ -831,7 +831,7 @@ class streamTests: XCTestCase
     _ = paused.countEvents()
     postAndWait()
 
-    XCTAssertEqual(stream.requested, Int64.max)
+    XCTAssertEqual(stream.requested, Int64.max, "stream.requested at \(#line)")
     paused.close()
   }
 }


### PR DESCRIPTION
`EventStream.updateRequest` did not treat `Int64.max` differently from any other value, and thus was liable to return something like `Int64.max - 2` to a subclass's overridden implementation, which could then get forwarded to a subscription, and eventually one's expectation that some instance's `requested` property should equal `Int64.max` might not actually be correct.