### PR TITLE
un-silenced the various DispatchQueue parameter labels

### DIFF
--- a/Sources/ReactiveStreams/deferred-next.swift
+++ b/Sources/ReactiveStreams/deferred-next.swift
@@ -14,10 +14,10 @@ extension EventStream
   public func next(qos: DispatchQoS? = nil) -> Deferred<Value>
   {
     let queue = DispatchQueue(label: "stream-to-deferred", qos: qos ?? self.qos)
-    return next(queue)
+    return next(queue: queue)
   }
 
-  public func next(_ queue: DispatchQueue) -> Deferred<Value>
+  public func next(queue: DispatchQueue) -> Deferred<Value>
   {
     let tbd = TBD<Value>(queue: queue)
     var deferred: SingleValueSubscriber<Value>!

--- a/Sources/ReactiveStreams/stream-final.swift
+++ b/Sources/ReactiveStreams/stream-final.swift
@@ -43,8 +43,8 @@ extension EventStream
     return finalValue(LimitedStream<Value>(qos: qos ?? self.qos, count: 1))
   }
 
-  public func finalValue(_ queue: DispatchQueue) -> EventStream<Value>
+  public func finalValue(queue: DispatchQueue) -> EventStream<Value>
   {
-    return finalValue(LimitedStream<Value>(queue, count: 1))
+    return finalValue(LimitedStream<Value>(queue: queue, count: 1))
   }
 }

--- a/Sources/ReactiveStreams/stream-limited.swift
+++ b/Sources/ReactiveStreams/stream-limited.swift
@@ -20,7 +20,7 @@ open class LimitedStream<Value>: SubStream<Value>
     self.init(validated: ValidatedQueue(label: "limitedstream", qos: qos), count: max(count,0))
   }
 
-  public convenience init(_ queue: DispatchQueue, count: Int64)
+  public convenience init(queue: DispatchQueue, count: Int64)
   {
     self.init(validated: ValidatedQueue(label: "limitedstream", target: queue), count: max(count,0))
   }

--- a/Sources/ReactiveStreams/stream-map.swift
+++ b/Sources/ReactiveStreams/stream-map.swift
@@ -32,9 +32,9 @@ extension EventStream
     return map(SubStream<U>(qos: qos ?? self.qos), transform: transform)
   }
 
-  public func map<U>(_ queue: DispatchQueue, transform: @escaping (Value) throws -> U) -> EventStream<U>
+  public func map<U>(queue: DispatchQueue, transform: @escaping (Value) throws -> U) -> EventStream<U>
   {
-    return map(SubStream<U>(queue), transform: transform)
+    return map(SubStream<U>(queue: queue), transform: transform)
   }
 }
 
@@ -62,8 +62,8 @@ extension EventStream
     return map(SubStream<U>(qos: qos ?? self.qos), transform: transform)
   }
 
-  public func map<U>(_ queue: DispatchQueue, transform: @escaping (Value) throws -> Event<U>) -> EventStream<U>
+  public func map<U>(queue: DispatchQueue, transform: @escaping (Value) throws -> Event<U>) -> EventStream<U>
   {
-    return map(SubStream<U>(queue), transform: transform)
+    return map(SubStream<U>(queue: queue), transform: transform)
   }
 }

--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -22,7 +22,7 @@ public class MergeStream<Value>: SubStream<Value>
     self.init(validated: ValidatedQueue(label: "eventstream", qos: qos), delayingErrors: delay)
   }
 
-  fileprivate convenience init(_ queue: DispatchQueue, delayingErrors delay: Bool)
+  fileprivate convenience init(queue: DispatchQueue, delayingErrors delay: Bool)
   {
     self.init(validated: ValidatedQueue(label: "eventstream", target: queue), delayingErrors: delay)
   }
@@ -143,7 +143,7 @@ internal class FlatMapStream<Value>: MergeStream<Value>
     self.init(validated: ValidatedQueue(label: "eventstream", qos: qos))
   }
 
-  convenience init(_ queue: DispatchQueue)
+  convenience init(queue: DispatchQueue)
   {
     self.init(validated: ValidatedQueue(label: "eventstream", target: queue))
   }
@@ -207,9 +207,9 @@ extension EventStream
     return flatMap(FlatMapStream(qos: qos ?? self.qos), transform: transform)
   }
 
-  public func flatMap<U>(_ queue: DispatchQueue, transform: @escaping (Value) -> EventStream<U>) -> EventStream<U>
+  public func flatMap<U>(queue: DispatchQueue, transform: @escaping (Value) -> EventStream<U>) -> EventStream<U>
   {
-    return flatMap(FlatMapStream(queue), transform: transform)
+    return flatMap(FlatMapStream(queue: queue), transform: transform)
   }
 }
 
@@ -238,10 +238,10 @@ extension EventStream
     return merged
   }
 
-  static public func merge<S: Sequence>(_ queue: DispatchQueue, streams: S, delayingErrors delay: Bool = false) -> EventStream<Value>
+  static public func merge<S: Sequence>(queue: DispatchQueue, streams: S, delayingErrors delay: Bool = false) -> EventStream<Value>
     where S.Iterator.Element: EventStream<Value>
   {
-    let merged = MergeStream<Value>(queue, delayingErrors: delay)
+    let merged = MergeStream<Value>(queue: queue, delayingErrors: delay)
     merge(streams: streams, into: merged)
     return merged
   }

--- a/Sources/ReactiveStreams/stream-next.swift
+++ b/Sources/ReactiveStreams/stream-next.swift
@@ -17,9 +17,9 @@ extension EventStream
     return stream
   }
 
-  public func next(_ queue: DispatchQueue, count: Int) -> EventStream<Value>
+  public func next(queue: DispatchQueue, count: Int) -> EventStream<Value>
   {
-    let stream = LimitedStream<Value>(queue, count: Int64(count))
+    let stream = LimitedStream<Value>(queue: queue, count: Int64(count))
     self.subscribe(substream: stream)
     return stream
   }

--- a/Sources/ReactiveStreams/stream-notifications.swift
+++ b/Sources/ReactiveStreams/stream-notifications.swift
@@ -83,7 +83,7 @@ extension EventStream
     performNotify(ValidatedQueue(label: "notify", qos: qos ?? self.qos), task: task)
   }
 
-  public func notify(_ queue: DispatchQueue, task: @escaping (Event<Value>) -> Void)
+  public func notify(queue: DispatchQueue, task: @escaping (Event<Value>) -> Void)
   {
     performNotify(ValidatedQueue(label: "notify", target: queue), task: task)
   }
@@ -103,7 +103,7 @@ extension EventStream
     performOnValue(ValidatedQueue(label: "onvalue", qos: qos ?? self.qos), task: task)
   }
 
-  public func onValue(_ queue: DispatchQueue, task: @escaping (Value) -> Void)
+  public func onValue(queue: DispatchQueue, task: @escaping (Value) -> Void)
   {
     performOnValue(ValidatedQueue(label: "onvalue", target: queue), task: task)
   }
@@ -114,10 +114,10 @@ extension EventStream
   public func onError(qos: DispatchQoS? = nil, task: @escaping (Error) -> Void)
   {
     let queue = DispatchQueue(label: "concurrent", qos: qos ?? self.qos, attributes: .concurrent)
-    onError(queue, task: task)
+    onError(queue: queue, task: task)
   }
 
-  public func onError(_ queue: DispatchQueue, task: @escaping (Error) -> Void)
+  public func onError(queue: DispatchQueue, task: @escaping (Error) -> Void)
   {
     let notifier = NotificationSubscriber<Value>(queue)
     notifier.errorHandler = { error in withExtendedLifetime(notifier) { task(error) } }
@@ -130,10 +130,10 @@ extension EventStream
   public func onCompletion(qos: DispatchQoS? = nil, task: @escaping () -> Void)
   {
     let queue = DispatchQueue(label: "concurrent", qos: qos ?? self.qos, attributes: .concurrent)
-    onCompletion(queue, task: task)
+    onCompletion(queue: queue, task: task)
   }
 
-  public func onCompletion(_ queue: DispatchQueue, task: @escaping () -> Void)
+  public func onCompletion(queue: DispatchQueue, task: @escaping () -> Void)
   {
     let notifier = NotificationSubscriber<Value>(queue)
     notifier.completionHandler = { withExtendedLifetime(notifier) { task() } }

--- a/Sources/ReactiveStreams/stream-onrequest.swift
+++ b/Sources/ReactiveStreams/stream-onrequest.swift
@@ -20,7 +20,7 @@ open class OnRequestStream: EventStream<Int>
     self.init(validated: ValidatedQueue(label: "onrequeststream", qos: qos), autostart: autostart)
   }
 
-  public convenience init(_ queue: DispatchQueue, autostart: Bool = true)
+  public convenience init(queue: DispatchQueue, autostart: Bool = true)
   {
     self.init(validated: ValidatedQueue(label: "onrequeststream", target: queue), autostart: autostart)
   }

--- a/Sources/ReactiveStreams/stream-reduce.swift
+++ b/Sources/ReactiveStreams/stream-reduce.swift
@@ -68,7 +68,7 @@ extension EventStream
     return reduce(ReducingStream(queue, initial: initial, combiner: combiner))
   }
 
-  public func reduce<U>(_ queue: DispatchQueue, _ initial: U, _ combiner: @escaping (U, Value) throws -> U) -> EventStream<U>
+  public func reduce<U>(queue: DispatchQueue, _ initial: U, _ combiner: @escaping (U, Value) throws -> U) -> EventStream<U>
   {
     let queue = ValidatedQueue(label: "reducing-queue", target: queue)
     return reduce(ReducingStream(queue, initial: initial, combiner: combiner))
@@ -80,7 +80,7 @@ extension EventStream
     return reduce(ReducingStream(queue, initial: initial, combiner: combiner))
   }
 
-  public func reduce<U>(_ queue: DispatchQueue, into initial: U, _ combiner: @escaping (inout U, Value) throws -> Void) -> EventStream<U>
+  public func reduce<U>(queue: DispatchQueue, into initial: U, _ combiner: @escaping (inout U, Value) throws -> Void) -> EventStream<U>
   {
     let queue = ValidatedQueue(label: "reducing-queue", target: queue)
     return reduce(ReducingStream(queue, initial: initial, combiner: combiner))
@@ -94,9 +94,9 @@ extension EventStream
     return self.reduce(qos: qos, into: 0) { (count: inout Int, _) in count += 1 }
   }
 
-  public func countEvents(_ queue: DispatchQueue) -> EventStream<Int>
+  public func countEvents(queue: DispatchQueue) -> EventStream<Int>
   {
-    return self.reduce(queue, into: 0) { (count: inout Int, _) in count += 1 }
+    return self.reduce(queue: queue, into: 0) { (count: inout Int, _) in count += 1 }
   }
 }
 
@@ -108,8 +108,8 @@ extension EventStream
     return self.reduce(qos: qos, into: []) { (c: inout [Value], e: Value) in c.append(e) }
   }
 
-  public func coalesce(_ queue: DispatchQueue) -> EventStream<[Value]>
+  public func coalesce(queue: DispatchQueue) -> EventStream<[Value]>
   {
-    return self.reduce(queue, into: []) { (c: inout [Value], e: Value) in c.append(e) }
+    return self.reduce(queue: queue, into: []) { (c: inout [Value], e: Value) in c.append(e) }
   }
 }

--- a/Sources/ReactiveStreams/stream-skip.swift
+++ b/Sources/ReactiveStreams/stream-skip.swift
@@ -39,8 +39,8 @@ extension EventStream
     return skip(SubStream<Value>(qos: qos ?? self.qos), count: count)
   }
 
-  public func skip(_ queue: DispatchQueue, count: Int) -> EventStream<Value>
+  public func skip(queue: DispatchQueue, count: Int) -> EventStream<Value>
   {
-    return skip(SubStream<Value>(queue), count: count)
+    return skip(SubStream<Value>(queue: queue), count: count)
   }
 }

--- a/Sources/ReactiveStreams/stream.swift
+++ b/Sources/ReactiveStreams/stream.swift
@@ -49,7 +49,7 @@ open class EventStream<Value>: Publisher
     self.init(validated: ValidatedQueue(label: "eventstream", qos: qos))
   }
 
-  public convenience init(_ queue: DispatchQueue)
+  public convenience init(queue: DispatchQueue)
   {
     self.init(validated: ValidatedQueue(label: "eventstream", target: queue))
   }

--- a/Tests/ReactiveStreamsTests/flatMapTests.swift
+++ b/Tests/ReactiveStreamsTests/flatMapTests.swift
@@ -69,7 +69,7 @@ class flatMapTests: XCTestCase
 
     let e = expectation(description: "observation ends \(#function)")
 
-    let m = s.flatMap(DispatchQueue.global()) {
+    let m = s.flatMap(queue: DispatchQueue.global()) {
       count -> EventStream<Double> in
       let s = EventStream<Double>()
       s.close()

--- a/Tests/ReactiveStreamsTests/mergeTests.swift
+++ b/Tests/ReactiveStreamsTests/mergeTests.swift
@@ -149,7 +149,7 @@ class mergeTests: XCTestCase
     let e = expectation(description: "observation ends \(#function)")
     let count = 10
 
-    let merged = EventStream.merge(DispatchQueue.global(qos: .utility), streams: [s])
+    let merged = EventStream.merge(queue: DispatchQueue.global(qos: .utility), streams: [s])
     merged.onValue { if $0 == count { e.fulfill() } }
 
     for i in 0..<count { s.post(i+1) }
@@ -309,8 +309,8 @@ class mergeTests: XCTestCase
   {
     let id = nzRandom()
 
-    let q = DispatchQueue(label: "delaying error test")
-    let streams = (0..<10).map { _ in PostBox<Int>(q) }
+    let queue = DispatchQueue(label: "delaying error test")
+    let streams = (0..<10).map { _ in PostBox<Int>(queue: queue) }
 
     let merged = EventStream.merge(streams: streams, delayingErrors: true)
     let x = expectation(description: "correct delayed error")

--- a/Tests/ReactiveStreamsTests/onRequestTests.swift
+++ b/Tests/ReactiveStreamsTests/onRequestTests.swift
@@ -16,7 +16,7 @@ class onRequestTests: XCTestCase
   {
     let e = expectation(description: "on-request")
 
-    let o = OnRequestStream(DispatchQueue.global(qos: .background), autostart: false)
+    let o = OnRequestStream(queue: DispatchQueue.global(qos: .background), autostart: false)
 
     o.next(count: 10).reduce(0, +).notify {
       event in


### PR DESCRIPTION
This makes the shape of the transformation functions more similar to those for `Deferred`.
In `Deferred`, the functions with a `DispatchQueue` have a default (`nil`) that means "use the one used by the source", while for `EventSource`, the functions with a `DispatchQoS` have a default (`nil`) that means "used the one used by the source". The difference just points to which parameter is most logically shared by a source and its dependent.