### PR TITLE
updateRequest vs. processAdditionalRequest

### DIFF
--- a/Sources/ReactiveStreams/deferred-stream.swift
+++ b/Sources/ReactiveStreams/deferred-stream.swift
@@ -36,16 +36,14 @@ public class SingleValueStream<Value>: EventStream<Value>
     }
   }
 
-  @discardableResult
-  open override func updateRequest(_ requested: Int64) -> Int64
+  open override func updateRequest(_ requested: Int64)
   { // only pass on requested updates up to and including our remaining number of events
     precondition(requested > 0)
 
     if deferred?.isDetermined == false
     {
-      return super.updateRequest(1)
+      super.updateRequest(1)
     }
-    return 0
   }
 }
 

--- a/Sources/ReactiveStreams/publisher.swift
+++ b/Sources/ReactiveStreams/publisher.swift
@@ -8,7 +8,7 @@
 
 public protocol EventSource: class
 {
-  @discardableResult func updateRequest(_ requested: Int64) -> Int64
+  func updateRequest(_ requested: Int64)
   func cancel(subscription: Subscription)
 }
 

--- a/Sources/ReactiveStreams/stream-limited.swift
+++ b/Sources/ReactiveStreams/stream-limited.swift
@@ -52,13 +52,15 @@ open class LimitedStream<Value>: SubStream<Value>
     }
   }
 
-  @discardableResult
-  open override func updateRequest(_ requested: Int64) -> Int64
+  open override func updateRequest(_ requested: Int64)
   { // only pass on requested updates up to and including our remaining number of events
     precondition(requested > 0)
 
     let remaining = (limit-count)
-    let adjusted = min(requested, max(remaining, 1))
-    return super.updateRequest(adjusted)
+    let adjusted = min(requested, remaining)
+    if adjusted > 0
+    {
+      super.updateRequest(adjusted)
+    }
   }
 }

--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -122,9 +122,9 @@ public class MergeStream<Value>: SubStream<Value>
     }
   }
 
-  override func request(_ additional: Int64)
+  override public func processAdditionalRequest(_ additional: Int64)
   {
-    super.request(additional)
+    super.processAdditionalRequest(additional)
     // copy set of subscriptions so that a modification on the main queue
     // will not interfere. (is this too optimistic? should this use
     // dispatch_barrier_async instead? (or a lock?))

--- a/Sources/ReactiveStreams/stream-onrequest.swift
+++ b/Sources/ReactiveStreams/stream-onrequest.swift
@@ -53,17 +53,12 @@ open class OnRequestStream: EventStream<Int>
     processNext()
   }
 
-  @discardableResult
-  override open func updateRequest(_ requested: Int64) -> Int64
+  override open func processAdditionalRequest(_ additional: Int64)
   {
-    let additionalRequest = super.updateRequest(requested)
-    if additionalRequest > 0
-    {
-      if started.load(.relaxed)
-      { // enqueue some event processing in case stream had been paused
-        processNext()
-      }
+    super.processAdditionalRequest(additional)
+    if started.load(.relaxed)
+    { // enqueue some event processing in case stream had been paused
+      processNext()
     }
-    return additionalRequest
   }
 }

--- a/Sources/ReactiveStreams/stream-paused.swift
+++ b/Sources/ReactiveStreams/stream-paused.swift
@@ -22,12 +22,12 @@ open class Paused<Value>: SubStream<Value>
     stream.subscribe(substream: self)
   }
 
-  @discardableResult
-  open override func updateRequest(_ requested: Int64) -> Int64
+  open override func updateRequest(_ requested: Int64)
   {
     if started.load(.relaxed) == true
     {
-      return super.updateRequest(requested)
+      super.updateRequest(requested)
+      return
     }
 
     precondition(requested > 0)
@@ -35,12 +35,10 @@ open class Paused<Value>: SubStream<Value>
     var updated: Int64
     var current = torequest.load(.relaxed)
     repeat {
-      if current == .max { return .max }
+      if current == .max { return }
       updated = current &+ requested // could overflow; avoid trapping
       if updated < 0 { updated = .max } // check and correct for overflow
     } while !torequest.loadCAS(&current, updated, .weak, .relaxed, .relaxed)
-
-    return updated
   }
 
   open func start()

--- a/Sources/ReactiveStreams/stream-reduce.swift
+++ b/Sources/ReactiveStreams/stream-reduce.swift
@@ -46,11 +46,10 @@ class ReducingStream<InputValue, OutputValue>: SubStream<OutputValue>
     }
   }
 
-  @discardableResult
-  override func updateRequest(_ requested: Int64) -> Int64
+  override func updateRequest(_ requested: Int64)
   { // only pass on requested updates up to and including our remaining number of events
     precondition(requested > 0)
-    return super.updateRequest(1)
+    super.updateRequest(1)
   }
 }
 

--- a/Sources/ReactiveStreams/stream-substream.swift
+++ b/Sources/ReactiveStreams/stream-substream.swift
@@ -39,19 +39,9 @@ open class SubStream<Value>: EventStream<Value>
     super.finalizeStream()
   }
 
-  @discardableResult
-  open override func updateRequest(_ requested: Int64) -> Int64
+  override open func processAdditionalRequest(_ additional: Int64)
   {
-    let additional = super.updateRequest(requested)
-    if additional > 0
-    {
-      request(additional)
-    }
-    return additional
-  }
-
-  func request(_ additional: Int64)
-  {
+    super.processAdditionalRequest(additional)
     let subscription = sub.load()
     subscription?.request(additional)
   }


### PR DESCRIPTION
separate one customization point into two

This clarifies the distinction between some subclasses of `EventStream`
a) sometimes you want to change the number passed to `updateRequest`
b) sometimes you want to do something in response to the change in the requested number of items

In case (a), the overridden behaviour occurs (should occur) before the atomic operation
In case (b), the overridden behaviour occurs after the atomic operation

Either way, this makes the `EventSource` more straightforward as it doesn't leak a weird implementation detail.