### PR TITLE
distinguish more between StreamCompleted.{normally,lateSubscription}

### DIFF
--- a/Sources/ReactiveStreams/event.swift
+++ b/Sources/ReactiveStreams/event.swift
@@ -26,9 +26,10 @@ extension Event
   }
 
   public var streamError: Error? {
-    if let error = error, !(error is StreamCompleted)
-    { return error }
-
-    return nil
+    guard let error = error else { return nil }
+    if let completed = error as? StreamCompleted,
+       completed == .normally
+    { return nil }
+    return error
   }
 }

--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -74,7 +74,7 @@ public class MergeStream<Value>: SubStream<Value>
           if event.isValue == false
           { // event terminates merged stream; remove it from sources
             merged.subscriptions.remove(subscription)
-            if event.streamCompleted != nil
+            if event.error is StreamCompleted
             { // merged stream completed normally
               if (merged.closeWhenLastSourceCloses || merged.closed), merged.subscriptions.isEmpty
               { // no other event is forthcoming from any stream
@@ -86,11 +86,11 @@ public class MergeStream<Value>: SubStream<Value>
             else if merged.delayErrorReporting
             {
               let error = merged.delayedError ?? event.streamError!
-              merged.delayedError = error
               if merged.subscriptions.isEmpty
               {
                 merged.dispatch(Event(error: error))
               }
+              merged.delayedError = error
               return
             }
           }
@@ -190,7 +190,7 @@ extension EventStream
           do {
             merged.performMerge(transform(try event.get()))
           }
-          catch StreamCompleted.normally {
+          catch is StreamCompleted {
             merged.closeFlatMap()
           }
           catch {

--- a/Sources/ReactiveStreams/subscriber.swift
+++ b/Sources/ReactiveStreams/subscriber.swift
@@ -23,7 +23,7 @@ extension Subscriber
     do {
       self.onValue(try event.get())
     }
-    catch is StreamCompleted {
+    catch StreamCompleted.normally {
       self.onCompletion()
     }
     catch {

--- a/Tests/ReactiveStreamsTests/eventTests.swift
+++ b/Tests/ReactiveStreamsTests/eventTests.swift
@@ -15,22 +15,27 @@ class eventTests: XCTestCase
   func testGetters() throws
   {
     let value = Event<Int>(value: .max)
-    let error = Event<Int>(error: TestError.value(.min))
-    let final = Event<Int>.streamCompleted
-
     XCTAssertNotNil(value.value)
     XCTAssertNil(value.streamError)
     XCTAssertNil(value.streamCompleted)
     XCTAssertNil(value.error)
 
+    let error = Event<Int>(error: TestError.value(.min))
     XCTAssertNil(error.value)
     XCTAssertNotNil(error.streamError)
     XCTAssertNil(error.streamCompleted)
     XCTAssertNotNil(error.error)
 
+    let final = Event<Int>.streamCompleted
     XCTAssertNil(final.value)
     XCTAssertNil(final.streamError)
     XCTAssertNotNil(final.streamCompleted)
     XCTAssertNotNil(final.error)
+
+    let tardy = Event<Int>(error: StreamCompleted.lateSubscription)
+    XCTAssertNil(tardy.value)
+    XCTAssertNotNil(tardy.streamError)
+    XCTAssertNotNil(tardy.streamCompleted)
+    XCTAssertNotNil(tardy.error)
   }
 }

--- a/Tests/ReactiveStreamsTests/mergeTests.swift
+++ b/Tests/ReactiveStreamsTests/mergeTests.swift
@@ -28,8 +28,8 @@ class mergeTests: XCTestCase
         let value = try event.get()
         XCTAssertEqual(value, count)
       }
-      catch is StreamCompleted { e1.fulfill() }
-      catch {}
+      catch StreamCompleted.normally { e1.fulfill() }
+      catch { XCTFail(String(describing: error)) }
     }
 
     XCTAssertEqual(merged.requested, .max)
@@ -60,8 +60,8 @@ class mergeTests: XCTestCase
         let value = try event.get()
         XCTAssertEqual(value, 0)
       }
-      catch is StreamCompleted { e1.fulfill() }
-      catch { print(error) }
+      catch StreamCompleted.normally { e1.fulfill() }
+      catch { XCTFail(String(describing: error)) }
     }
 
     // merged stream is closed before any events come through,

--- a/Tests/ReactiveStreamsTests/onRequestTests.swift
+++ b/Tests/ReactiveStreamsTests/onRequestTests.swift
@@ -25,8 +25,8 @@ class onRequestTests: XCTestCase
         if value == 45 { e.fulfill() }
         else { XCTFail() }
       }
-      catch is StreamCompleted {}
-      catch { XCTFail() }
+      catch StreamCompleted.normally {}
+      catch { XCTFail(String(describing: error)) }
     }
 
     o.start()
@@ -80,8 +80,8 @@ class onRequestTests: XCTestCase
         if value == 45 { e0.fulfill() }
         else { XCTFail() }
       }
-      catch is StreamCompleted {}
-      catch { XCTFail() }
+      catch StreamCompleted.normally {}
+      catch { XCTFail(String(describing: error)) }
     }
     p0.start()
 
@@ -97,8 +97,8 @@ class onRequestTests: XCTestCase
         if value == 145 { e1.fulfill() }
         else { XCTFail() }
       }
-      catch is StreamCompleted {}
-      catch { XCTFail() }
+      catch StreamCompleted.normally {}
+      catch { XCTFail(String(describing: error)) }
     }
     p1.start()
 


### PR DESCRIPTION
- getting an explicit .lateSubscription somewhere may be for debugging.
- too many code paths conflated the two for no good reason.