### PR TITLE
Change the PostBox stream to buffer its input in a multiple-producer queue

### DIFF
--- a/Sources/ReactiveStreams/stream-post.swift
+++ b/Sources/ReactiveStreams/stream-post.swift
@@ -6,18 +6,66 @@
 //  Copyright © 2016 Guillaume Lessard. All rights reserved.
 //
 
+import Dispatch
+import CAtomics
+
 open class PostBox<Value>: EventStream<Value>
 {
+  private typealias Node = BufferNode<Event<Value>>
+
+  private var hptr: AtomicNonNullMutableRawPointer
+  private var head: Node {
+    get { return Node(storage: hptr.load(.relaxed)) }
+    set { hptr.store(newValue.storage, .relaxed) }
+  }
+  private var tptr: AtomicNonNullMutableRawPointer
+  private var fptr: AtomicOptionalMutableRawPointer
+
   override init(validated: ValidatedQueue)
-  {
+  { // set up an initial dummy node
+    let node = Node.dummy
+    hptr = AtomicNonNullMutableRawPointer(node.storage)
+    tptr = AtomicNonNullMutableRawPointer(node.storage)
+    fptr = AtomicOptionalMutableRawPointer(nil)
     super.init(validated: validated)
   }
 
+  deinit {
+    // empty the queue
+    let head = self.head
+    var next = head.next
+    while let node = next
+    {
+      next = node.next
+      node.deinitialize()
+      node.deallocate()
+    }
+    head.deallocate()
+  }
+
+  final public var isEmpty: Bool { return hptr.load(.relaxed) == tptr.load(.relaxed) }
+
   final public func post(_ event: Event<Value>)
   {
-    guard !completed else { return }
-    self.queue.async {
-      self.dispatch(event)
+    guard completed == false, fptr.load(.relaxed) == nil else { return }
+
+    let node = Node(initializedWith: event)
+    if event.isError
+    {
+      guard fptr.CAS(nil, node.storage, .strong, .relaxed) else { return }
+    }
+
+    // events posted "simultaneously" synchronize with each other here
+    let previousTailPointer = self.tptr.swap(node.storage, .acqrel)
+    let previousTail = Node(storage: previousTailPointer)
+
+    // publish the new node to processing loop here
+    previousTail.nptr.store(node.storage, .release)
+
+    if previousTailPointer == hptr.load(.relaxed)
+    { // the queue had been empty or blocked
+      // resume processing enqueued events
+      queue.async(execute: self.processNext)
     }
   }
 
@@ -29,5 +77,116 @@ open class PostBox<Value>: EventStream<Value>
   final public func post(_ error: Error)
   {
     post(Event(error: error))
+  }
+
+  open override func close()
+  {
+    post(Event.streamCompleted)
+  }
+
+  private func processNext()
+  {
+#if DEBUG && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+    if #available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)
+    {
+      dispatchPrecondition(condition: .onQueue(queue))
+    }
+#endif
+
+    // try to dequeue the next event
+    let oldHead = head
+    let next = oldHead.nptr.load(.acquire)
+
+    if requested <= 0 && fptr.load(.relaxed) != next { return }
+
+    if let next = Node(storage: next)
+    {
+      let event = next.move()
+      head = next
+      oldHead.deallocate()
+
+      dispatch(event)
+      queue.async(execute: self.processNext)
+      return
+    }
+
+    // Either the queue is empty, or processing is blocked.
+    // Either way, processing will resume once
+    // a node has been linked after the current `head`
+  }
+
+  open override func processAdditionalRequest(_ additional: Int64)
+  {
+    super.processAdditionalRequest(additional)
+    // enqueue some event processing, in case stream had been paused
+    queue.async(execute: self.processNext)
+  }
+}
+
+private let nextOffset = 0
+private let dataOffset = (MemoryLayout<AtomicOptionalMutableRawPointer>.stride + 15) & ~15
+
+private struct BufferNode<Element>: Equatable
+{
+  let storage: UnsafeMutableRawPointer
+
+  init(storage: UnsafeMutableRawPointer)
+  {
+    self.storage = storage
+  }
+
+  init?(storage: UnsafeMutableRawPointer?)
+  {
+    guard let storage = storage else { return nil }
+    self.storage = storage
+  }
+
+  private init()
+  {
+    let size = dataOffset + MemoryLayout<Element>.stride
+    storage = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: 16)
+    (storage+nextOffset).bindMemory(to: AtomicOptionalMutableRawPointer.self, capacity: 1)
+    nptr = AtomicOptionalMutableRawPointer(nil)
+    (storage+dataOffset).bindMemory(to: Element.self, capacity: 1)
+  }
+
+  static var dummy: BufferNode { return BufferNode() }
+
+  init(initializedWith element: Element)
+  {
+    self.init()
+    data.initialize(to: element)
+  }
+
+  func deallocate()
+  {
+    storage.deallocate()
+  }
+
+  var nptr: AtomicOptionalMutableRawPointer {
+    unsafeAddress {
+      return UnsafeRawPointer(storage+nextOffset).assumingMemoryBound(to: AtomicOptionalMutableRawPointer.self)
+    }
+    nonmutating unsafeMutableAddress {
+      return (storage+nextOffset).assumingMemoryBound(to: AtomicOptionalMutableRawPointer.self)
+    }
+  }
+
+  var next: BufferNode? {
+    get { return BufferNode(storage: nptr.load(.acquire)) }
+  }
+
+  private var data: UnsafeMutablePointer<Element> {
+    return (storage+dataOffset).assumingMemoryBound(to: Element.self)
+  }
+
+  func deinitialize()
+  {
+    data.deinitialize(count: 1)
+  }
+
+  func move() -> Element
+  {
+    return data.move()
   }
 }

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -92,6 +92,18 @@ extension onRequestTests {
     ]
 }
 
+extension postBoxTests {
+    static let __allTests = [
+        ("testPerformanceDequeue", testPerformanceDequeue),
+        ("testPostAfterCompletion", testPostAfterCompletion),
+        ("testPostConcurrentProducers", testPostConcurrentProducers),
+        ("testPostDeinitWithPendingEvents", testPostDeinitWithPendingEvents),
+        ("testPostDoubleTermination", testPostDoubleTermination),
+        ("testPostErrorWithoutRequest", testPostErrorWithoutRequest),
+        ("testPostNormal", testPostNormal),
+    ]
+}
+
 extension reduceTests {
     static let __allTests = [
         ("testCoalesce", testCoalesce),
@@ -114,7 +126,6 @@ extension streamTests {
         ("testPaused1", testPaused1),
         ("testPaused2", testPaused2),
         ("testPaused3", testPaused3),
-        ("testPost", testPost),
         ("testSkipN", testSkipN),
         ("testSplit0", testSplit0),
         ("testSplit1", testSplit1),
@@ -154,6 +165,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(mergeTests.__allTests),
         testCase(notificationTests.__allTests),
         testCase(onRequestTests.__allTests),
+        testCase(postBoxTests.__allTests),
         testCase(reduceTests.__allTests),
         testCase(streamTests.__allTests),
         testCase(subscriberTests.__allTests),

--- a/Tests/ReactiveStreamsTests/deferredTests.swift
+++ b/Tests/ReactiveStreamsTests/deferredTests.swift
@@ -26,14 +26,15 @@ public class SingleValueSubscriberTests: XCTestCase
       notificationHandler: { $0.determine($1) }
     )
 
-    stream.post(1)
-    queue.sync {}
+    let r = nzRandom()
+    stream.post(r)
     XCTAssertNil(subscriber.peek())
 
     subscriber.request(1)
-    stream.post(2)
-    queue.sync {}
-    XCTAssertEqual(subscriber.value, 2)
+    stream.post(0)
+    XCTAssertEqual(subscriber.value, r)
+
+    stream.close()
   }
 
   func testSingleValueSubscriberWithError() throws
@@ -48,13 +49,11 @@ public class SingleValueSubscriberTests: XCTestCase
       notificationHandler: { $0.determine($1) }
     )
 
-    stream.post(1)
-    queue.sync {}
     XCTAssertNil(subscriber.peek())
 
-    stream.post(TestError(2))
-    queue.sync {}
-    XCTAssertEqual(subscriber.error as? TestError, TestError(2))
+    let r = nzRandom()
+    stream.post(TestError(r))
+    XCTAssertEqual(subscriber.error as? TestError, TestError(r))
   }
 
   func testSingleValueSubscriberCancelled() throws

--- a/Tests/ReactiveStreamsTests/postBoxTests.swift
+++ b/Tests/ReactiveStreamsTests/postBoxTests.swift
@@ -1,0 +1,149 @@
+//
+//  streamTests.swift
+//  streamTests
+//
+//  Created by Guillaume Lessard on 29/04/2016.
+//  Copyright © 2016 Guillaume Lessard. All rights reserved.
+//
+
+import XCTest
+import Dispatch
+import ReactiveStreams
+import deferred
+
+class postBoxTests: XCTestCase
+{
+  func testPostNormal()
+  {
+    let e = expectation(description: #function)
+    let stream = PostBox<Int>()
+
+    XCTAssertEqual(stream.requested, 0)
+
+    stream.post(0)
+    stream.post(Event(value: 1))
+    stream.post(StreamCompleted.normally)
+
+    stream.reduce(0, +).notify {
+      event in
+      do {
+        let r = try event.get()
+        XCTAssertEqual(r, 1)
+      }
+      catch StreamCompleted.normally { e.fulfill() }
+      catch { XCTFail(String(describing: error)) }
+    }
+
+    waitForExpectations(timeout: 1.0)
+
+    XCTAssertEqual(stream.requested, .min)
+  }
+
+  func testPostAfterCompletion() throws
+  {
+    let stream = PostBox<Int>()
+
+    let d = stream.finalOutcome()
+
+    stream.post(StreamCompleted.normally)
+    stream.post(42)
+
+    do {
+      _ = try d.get()
+    }
+    catch DeferredError.canceled {}
+  }
+
+  func testPostDoubleTermination() throws
+  {
+    let stream = PostBox<Int>()
+
+    let d = stream.finalOutcome()
+
+    stream.post(StreamCompleted.normally)
+    stream.post(TestError(42))
+
+    do {
+      _ = try d.get()
+    }
+    catch DeferredError.canceled {}
+  }
+
+  func testPostErrorWithoutRequest()
+  {
+    let e = expectation(description: #function)
+    let stream = PostBox<Int>()
+
+    stream.onError {
+      error in
+      XCTAssert(error is TestError)
+      XCTAssertEqual(error as? TestError, TestError(-1))
+      e.fulfill()
+    }
+
+    XCTAssertEqual(stream.requested, 0)
+
+    stream.post(TestError(-1))
+
+    waitForExpectations(timeout: 1.0)
+  }
+
+  func testPostConcurrentProducers() throws
+  {
+    let producers = 2
+    let totalPosts = 10_000
+
+    let s = PostBox<Int>(qos: .userInitiated)
+    let c = s.countEvents(qos: .default).finalOutcome()
+
+    DispatchQueue.global(qos: .background).async {
+      DispatchQueue.concurrentPerform(iterations: producers) {
+        p in
+        let segment = totalPosts/producers
+        for i in 0..<segment { s.post(p*segment + i) }
+      }
+      s.close()
+    }
+
+    let posted = try c.get()
+    XCTAssertEqual(posted, (totalPosts/producers)*producers)
+  }
+
+  func testPostDeinitWithPendingEvents() throws
+  {
+    let s = {
+      () -> EventStream<Double> in
+      let p = PostBox<Int>()
+      XCTAssert(p.isEmpty)
+      for i in 0..<10 { p.post(i) }
+      XCTAssertFalse(p.isEmpty)
+      return p.map(transform: Double.init(_:))
+    }()
+
+    s.close()
+  }
+
+  func testPerformanceDequeue()
+  {
+    let iterations = 10_000
+
+#if (!swift(>=4.1) && os(Linux))
+    let metrics = XCTestCase.defaultPerformanceMetrics()
+#else
+    let metrics = XCTestCase.defaultPerformanceMetrics
+#endif
+    measureMetrics(metrics, automaticallyStartMeasuring: false) {
+      let s = PostBox<Int>()
+      for i in 0..<iterations { s.post(i) }
+      s.close()
+
+      let c = s.countEvents()
+
+      startMeasuring()
+      let count = c.finalOutcome().value
+      stopMeasuring()
+
+      XCTAssertEqual(count, iterations)
+    }
+  }
+}

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -88,24 +88,6 @@ class streamTests: XCTestCase
     // the SpyStream should leak because one of its observers is kept alive by the pointer
   }
 
-  func testPost()
-  {
-    let e1 = expectation(description: "closed")
-    let stream = PostBox<Int>()
-
-    stream.onCompletion { e1.fulfill() }
-
-    stream.post(0)
-    stream.post(Event(value: 1))
-    stream.post(StreamCompleted.normally)
-
-    waitForExpectations(timeout: 1.0)
-
-    stream.post(Int.max)
-    stream.post(Event(value: Int.min))
-    stream.post(TestError(-1))
-  }
-
   func testStreamState()
   {
     let s = PostBox<Int>()

--- a/Xcode/stream.xcodeproj/project.pbxproj
+++ b/Xcode/stream.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		03A0D5C11EB31C0600F4B44B /* stream-limited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A0D5C01EB31C0600F4B44B /* stream-limited.swift */; };
 		03A1465D2224966E00F4B44B /* mapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1465C2224966E00F4B44B /* mapTests.swift */; };
 		03A14662222497BC00F4B44B /* notificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A14661222497BC00F4B44B /* notificationTests.swift */; };
+		03A1469722259E6600F4B44B /* postBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1469322259E6600F4B44B /* postBoxTests.swift */; };
 		03D89FBE1CD46B4300F4B44B /* stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D89FBD1CD46B4300F4B44B /* stream.swift */; };
 		03D89FC01CD46C0700F4B44B /* event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D89FBF1CD46C0700F4B44B /* event.swift */; };
 		03E1929B1CE4432000F4B44B /* subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E1929A1CE4432000F4B44B /* subscription.swift */; };
@@ -155,6 +156,7 @@
 		03A0D5C01EB31C0600F4B44B /* stream-limited.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "stream-limited.swift"; sourceTree = "<group>"; };
 		03A1465C2224966E00F4B44B /* mapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapTests.swift; sourceTree = "<group>"; };
 		03A14661222497BC00F4B44B /* notificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notificationTests.swift; sourceTree = "<group>"; };
+		03A1469322259E6600F4B44B /* postBoxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = postBoxTests.swift; sourceTree = "<group>"; };
 		03B817B52218CD1C00F4B44B /* Package@swift-4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Package@swift-4.swift"; path = "../Package@swift-4.swift"; sourceTree = "<group>"; };
 		03BBC54F20E44A3D00F4B44B /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .travis.yml; path = ../.travis.yml; sourceTree = "<group>"; };
 		03D89FBD1CD46B4300F4B44B /* stream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = stream.swift; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 				035312372224946E00F4B44B /* eventTests.swift */,
 				035312342224946E00F4B44B /* streamTests.swift */,
 				0353122D2224946E00F4B44B /* onRequestTests.swift */,
+				03A1469322259E6600F4B44B /* postBoxTests.swift */,
 				03A14661222497BC00F4B44B /* notificationTests.swift */,
 				035312312224946E00F4B44B /* filterTests.swift */,
 				03A1465C2224966E00F4B44B /* mapTests.swift */,
@@ -560,6 +563,7 @@
 				035312432224946E00F4B44B /* mergeTests.swift in Sources */,
 				03A1465D2224966E00F4B44B /* mapTests.swift in Sources */,
 				0353123F2224946E00F4B44B /* reduceTests.swift in Sources */,
+				03A1469722259E6600F4B44B /* postBoxTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- the multiple producer queue is wait-free for producers
- the queue has a wait-free fast-path for its single consumer
- the consumer's slow path is blocking, but the blocking occurs between executing blocks on the dispatch queue.