### PR TITLE
update Event to wrap Result with compiler 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,11 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/glessard/swift-atomics.git", from: "5.0.0"),
-    .package(url: "https://github.com/glessard/outcome.git", from: "4.3.0"),
     .package(url: "https://github.com/glessard/CurrentQoS.git", from: "1.1.0"),
     .package(url: "https://github.com/glessard/deferred.git", from: "5.1.0"),
   ],
   targets: [
-    .target(name: "ReactiveStreams", dependencies: ["CAtomics", "Outcome", "CurrentQoS", "deferred"]),
+    .target(name: "ReactiveStreams", dependencies: ["CAtomics", "CurrentQoS", "deferred"]),
     .testTarget(name: "ReactiveStreamsTests", dependencies: ["ReactiveStreams"]),
   ],
   swiftLanguageVersions: [.v4, .v4_2, .v5]

--- a/Sources/ReactiveStreams/deferred-final.swift
+++ b/Sources/ReactiveStreams/deferred-final.swift
@@ -38,7 +38,11 @@ extension EventStream
           catch StreamCompleted.normally {
             if let value = latest
             {
+#if compiler(>=5.0)
+              resolver.resolve(.success(value))
+#else
               resolver.resolve(Event(value: value))
+#endif
             }
             else
             {

--- a/Sources/ReactiveStreams/deferred-subscriber.swift
+++ b/Sources/ReactiveStreams/deferred-subscriber.swift
@@ -39,3 +39,21 @@ public class SingleValueSubscriber<Value>: TBD<Value>
     subscription?.request(additional)
   }
 }
+
+extension Resolver
+{
+  @discardableResult
+  public func resolve(_ event: Event<Value>) -> Bool
+  {
+#if compiler(>=5.0)
+    return resolve(event.result ?? .failure(StreamCompleted.normally))
+#else
+    do {
+      return resolve(value: try event.get())
+    }
+    catch {
+      return resolve(error: error)
+    }
+#endif
+  }
+}

--- a/Sources/ReactiveStreams/stream-merge.swift
+++ b/Sources/ReactiveStreams/stream-merge.swift
@@ -74,7 +74,7 @@ public class MergeStream<Value>: SubStream<Value>
           if event.isValue == false
           { // event terminates merged stream; remove it from sources
             merged.subscriptions.remove(subscription)
-            if event.error is StreamCompleted
+            if event.completedNormally || (event.error is StreamCompleted) // for .lateSubscription
             { // merged stream completed normally
               if (merged.closeWhenLastSourceCloses || merged.closed), merged.subscriptions.isEmpty
               { // no other event is forthcoming from any stream
@@ -85,7 +85,7 @@ public class MergeStream<Value>: SubStream<Value>
             }
             else if merged.delayErrorReporting
             {
-              let error = merged.delayedError ?? event.streamError!
+              let error = merged.delayedError ?? event.error!
               if merged.subscriptions.isEmpty
               {
                 merged.dispatch(Event(error: error))

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -25,7 +25,10 @@ extension SingleValueSubscriberTests {
 
 extension eventTests {
     static let __allTests = [
+        ("testDescription", testDescription),
+        ("testEquals", testEquals),
         ("testGetters", testGetters),
+        ("testHashable", testHashable),
     ]
 }
 

--- a/Tests/ReactiveStreamsTests/eventTests.swift
+++ b/Tests/ReactiveStreamsTests/eventTests.swift
@@ -16,26 +16,77 @@ class eventTests: XCTestCase
   {
     let value = Event<Int>(value: .max)
     XCTAssertNotNil(value.value)
-    XCTAssertNil(value.streamError)
-    XCTAssertNil(value.streamCompleted)
     XCTAssertNil(value.error)
+    XCTAssertEqual(value.isValue, true)
+    XCTAssertEqual(value.isError, false)
+    XCTAssertEqual(value.completedNormally, false)
 
     let error = Event<Int>(error: TestError.value(.min))
     XCTAssertNil(error.value)
-    XCTAssertNotNil(error.streamError)
-    XCTAssertNil(error.streamCompleted)
     XCTAssertNotNil(error.error)
+    XCTAssertEqual(error.isValue, false)
+    XCTAssertEqual(error.isError, true)
+    XCTAssertEqual(error.completedNormally, false)
 
-    let final = Event<Int>.streamCompleted
-    XCTAssertNil(final.value)
-    XCTAssertNil(final.streamError)
-    XCTAssertNotNil(final.streamCompleted)
-    XCTAssertNotNil(final.error)
+    let finalA = Event<Int>.streamCompleted
+    let finalB = Event<Int>(error: StreamCompleted.normally)
+    XCTAssertNil(finalA.value)
+    XCTAssertNil(finalA.error)
+    XCTAssertEqual(finalA.completedNormally, true)
+    XCTAssertEqual(finalA, finalB)
 
     let tardy = Event<Int>(error: StreamCompleted.lateSubscription)
     XCTAssertNil(tardy.value)
-    XCTAssertNotNil(tardy.streamError)
-    XCTAssertNotNil(tardy.streamCompleted)
     XCTAssertNotNil(tardy.error)
+    XCTAssertEqual(tardy.completedNormally, false)
+  }
+
+  func testDescription()
+  {
+    let i1 = nzRandom()
+    let o1 = Event(value: i1)
+    let d1 = String(describing: o1)
+    XCTAssert(d1.contains(String(describing: i1)))
+
+    let e2 = TestError(nzRandom())
+    let o2 = Event<Unicode.Scalar>(error: e2)
+    let d2 = String(describing: o2)
+    XCTAssert(d2.contains(String(describing: e2)))
+
+    let o3 = Event<Error>.streamCompleted
+    let d3 = String(describing: o3)
+    XCTAssertEqual(d3, "Stream Completed")
+  }
+
+  func testEquals()
+  {
+    let i1 = nzRandom()
+    let i2 = nzRandom()
+    let i3 = i1*i2
+
+    let e3 = Event(value: i1*i2)
+    XCTAssert(e3 == Event(value: i3))
+    XCTAssert(e3 != Event(value: i2))
+
+    var e4 = e3
+    e4 = Event(error: TestError(i1))
+    XCTAssert(e3 != e4)
+    XCTAssert(e4 != Event(error: TestError(i2)))
+
+    var e5 = e4
+    e5 = Event.streamCompleted
+    XCTAssert(e5 != e3)
+    XCTAssert(e5 == Event.streamCompleted)
+  }
+
+  func testHashable()
+  {
+    let e1 = Event<Double>.streamCompleted
+    let e2 = Event(value: 5.1)
+    let e3 = Event<Double>(error: TestError())
+
+    let s: Set = [e1, e2, e3]
+
+    XCTAssertTrue(s.contains(e2))
   }
 }


### PR DESCRIPTION
- in order to allow for typed errors in the future, change stream-termination event to `nil`
- that's so obvious I can't believe I didn't think of it earlier.