### PR TITLE
zero subscribers means no requested events

### DIFF
--- a/Sources/ReactiveStreams/stream.swift
+++ b/Sources/ReactiveStreams/stream.swift
@@ -119,6 +119,12 @@ open class EventStream<Value>: Publisher
         self.observers.removeValue(forKey: ws)
       }
     }
+
+    if self.observers.isEmpty && (prev > 1)
+    { // try to reset `pending` to zero
+      prev = (prev == .max) ? .max : prev-1
+      CAtomicsCompareAndExchange(pending, prev, 0, .strong, .relaxed)
+    }
   }
 
   /// precondition: must run on this stream's serial queue

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -131,6 +131,7 @@ extension streamTests {
         ("testPaused1", testPaused1),
         ("testPaused2", testPaused2),
         ("testPaused3", testPaused3),
+        ("testRequested", testRequested),
         ("testSkipN", testSkipN),
         ("testSplit0", testSplit0),
         ("testSplit1", testSplit1),

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -88,6 +88,20 @@ class streamTests: XCTestCase
     // the SpyStream should leak because one of its observers is kept alive by the pointer
   }
 
+  func testRequested()
+  {
+    let stream = OnRequestStream()
+    XCTAssertEqual(stream.requested, 0)
+    let final = stream.finalOutcome()
+    XCTAssertEqual(stream.requested, .max)
+    final.cancel()
+
+    let mapped = stream.map(transform: { $0 })
+    XCTAssertNotEqual(stream.requested, .max)
+    XCTAssertEqual(stream.requested, 0)
+    mapped.close()
+  }
+
   func testStreamState()
   {
     let s = PostBox<Int>()


### PR DESCRIPTION
- after a stream goes to zero subscribers, set `requested` to zero as well
- this is back-pressure in action!
- in the absence of this, a stream whose `requested` value is large (or infinite) might keep processing and dispatching events, thereby using processor time for no reason. (oops).
- this is why back-pressure is important.