### PR TITLE
use a different approach for Subscription references

### DIFF
--- a/Sources/ReactiveStreams/stream-substream.swift
+++ b/Sources/ReactiveStreams/stream-substream.swift
@@ -6,35 +6,31 @@
 //  Copyright © 2016 Guillaume Lessard. All rights reserved.
 //
 
-import CAtomics
-
 open class SubStream<Value>: EventStream<Value>
 {
-  private var sub = UnsafeMutablePointer<OpaqueUnmanagedHelper>.allocate(capacity: 1)
+  private var sub: OneTime<Subscription>? = nil
 
   public override init(validated: ValidatedQueue)
   {
-    sub.initialize()
     super.init(validated: validated)
   }
 
   deinit
   {
-    let subscription = sub.take()
+    let subscription = sub?.take()
     subscription?.cancel()
-    sub.deallocate()
   }
 
   open func setSubscription(_ subscription: Subscription)
   {
-    sub.assign(subscription)
+    sub = sub ?? OneTime(subscription)
   }
 
   /// precondition: must run on a barrier block or a serial queue
 
   override open func finalizeStream()
   {
-    let subscription = sub.take()
+    let subscription = sub?.take()
     subscription?.cancel()
     super.finalizeStream()
   }
@@ -42,7 +38,6 @@ open class SubStream<Value>: EventStream<Value>
   override open func processAdditionalRequest(_ additional: Int64)
   {
     super.processAdditionalRequest(additional)
-    let subscription = sub.load()
-    subscription?.request(additional)
+    sub?.reference?.request(additional)
   }
 }


### PR DESCRIPTION
- they're set once and then nullable once.
- they should be readable from multiple threads
- the nulling functionality can be a single-thread capability

- this approach makes nulling the reference the expensive operation,
  while the more frequent operation (load/copy) is cheaper.