### PR TITLE
Add a Subscription parameter to the notification handler

### DIFF
--- a/Sources/ReactiveStreams/deferred-final.swift
+++ b/Sources/ReactiveStreams/deferred-final.swift
@@ -31,7 +31,7 @@ extension EventStream
           subscription.requestAll()
         },
         notificationHandler: {
-          event in
+          _, event in
           switch event.state
           {
           case .success(let value)?:

--- a/Sources/ReactiveStreams/deferred-next.swift
+++ b/Sources/ReactiveStreams/deferred-next.swift
@@ -29,7 +29,7 @@ extension EventStream
           sub = subscription
           subscription.request(1)
         },
-        notificationHandler: { resolver.resolve($0) }
+        notificationHandler: { resolver.resolve($1) }
       )
       return sub.unsafelyUnwrapped
     }

--- a/Sources/ReactiveStreams/stream-filter.swift
+++ b/Sources/ReactiveStreams/stream-filter.swift
@@ -16,21 +16,21 @@ extension EventStream
       subscriber: stream,
       subscriptionHandler: stream.setSubscription,
       notificationHandler: {
-      mapped, subscription, event in
-      let newEvent: Event<U>
-      do {
-        guard let transformed = try transform(event.get())
-        else {
-          subscription.request(1)
-          return
+        mapped, subscription, event in
+        let newEvent: Event<U>
+        do {
+          guard let transformed = try transform(event.get())
+          else {
+            subscription.request(1)
+            return
+          }
+          newEvent = Event(value: transformed)
         }
-        newEvent = Event(value: transformed)
+        catch {
+          newEvent = Event(error: error)
+        }
+        mapped.queue.async { mapped.dispatch(newEvent) }
       }
-      catch {
-        newEvent = Event(error: error)
-      }
-      mapped.queue.async { mapped.dispatch(newEvent) }
-    }
     )
     return stream
   }
@@ -68,21 +68,21 @@ extension EventStream
       subscriber: stream,
       subscriptionHandler: stream.setSubscription,
       notificationHandler: {
-      mapped, subscription, event in
-      let newEvent: Event<U>
-      do {
-        guard let value = try event.get()
-        else {
-          subscription.request(1)
-          return
+        mapped, subscription, event in
+        let newEvent: Event<U>
+        do {
+          guard let value = try event.get()
+          else {
+            subscription.request(1)
+            return
+          }
+          newEvent = Event(value: value)
         }
-        newEvent = Event(value: value)
+        catch {
+          newEvent = Event(error: error)
+        }
+        mapped.queue.async { mapped.dispatch(newEvent) }
       }
-      catch {
-        newEvent = Event(error: error)
-      }
-      mapped.queue.async { mapped.dispatch(newEvent) }
-    }
     )
     return stream
   }

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -91,8 +91,10 @@ extension notifierTests {
     static let __allTests = [
         ("testOnComplete", testOnComplete),
         ("testOnError", testOnError),
-        ("testOnEvent", testOnEvent),
-        ("testOnValue", testOnValue),
+        ("testOnEvent1", testOnEvent1),
+        ("testOnEvent2", testOnEvent2),
+        ("testOnValue1", testOnValue1),
+        ("testOnValue2", testOnValue2),
     ]
 }
 

--- a/Tests/ReactiveStreamsTests/deferredTests.swift
+++ b/Tests/ReactiveStreamsTests/deferredTests.swift
@@ -21,7 +21,7 @@ public class SingleValueSubscriberTests: XCTestCase
       var sub: Subscription? = nil
       stream.subscribe(
         subscriptionHandler: { sub = $0 },
-        notificationHandler: { resolver.resolve($0) }
+        notificationHandler: { resolver.resolve($1) }
       )
       return sub.unsafelyUnwrapped
     }

--- a/Tests/ReactiveStreamsTests/notificationTests.swift
+++ b/Tests/ReactiveStreamsTests/notificationTests.swift
@@ -12,7 +12,7 @@ import ReactiveStreams
 
 class notifierTests: XCTestCase
 {
-  func testOnEvent()
+  func testOnEvent1()
   {
     let events = 10
     let queue = DispatchQueue(label: #function, qos: .userInitiated)
@@ -55,7 +55,32 @@ class notifierTests: XCTestCase
     _ = notifier
   }
 
-  func testOnValue()
+  func testOnEvent2()
+  {
+    let stream = OnRequestStream()
+
+    let e = expectation(description: #function)
+    let notifier = StreamNotifier(stream, onEvent: {
+      subscription, event in
+      if let c = event.value
+      {
+        if c < 10
+        { subscription.request(1) }
+        else
+        { subscription.cancel() }
+      }
+      else
+      {
+        e.fulfill()
+      }
+    })
+    notifier.request(1)
+
+    waitForExpectations(timeout: 1.0)
+    _ = notifier
+  }
+
+  func testOnValue1()
   {
     let events = 10
     let queue = DispatchQueue(label: #function, qos: .userInitiated)
@@ -73,6 +98,29 @@ class notifierTests: XCTestCase
     waitForExpectations(timeout: 1.0)
 
     stream.onValue() { _ in XCTFail("Shouldn't receive any values after the stream has been closed") }
+    _ = notifier
+  }
+
+  func testOnValue2()
+  {
+    let stream = OnRequestStream()
+
+    let e = expectation(description: #function)
+    let notifier = StreamNotifier(stream, onValue: {
+      subscription, value in
+      if value < 10
+      {
+        subscription.request(1)
+      }
+      else
+      {
+        subscription.cancel()
+        e.fulfill()
+      }
+    })
+    notifier.request(1)
+
+    waitForExpectations(timeout: 1.0)
     _ = notifier
   }
 

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -140,7 +140,8 @@ class streamTests: XCTestCase
         subscription.request(1)
       },
       notificationHandler: {
-        if $0.isValue { s?.cancel() }
+        XCTAssert($0 === s)
+        if $1.isValue { s?.cancel() }
         else { e.fulfill() }
       }
     )

--- a/Xcode/stream.xcodeproj/xcshareddata/xcschemes/ReactiveStreams.xcscheme
+++ b/Xcode/stream.xcodeproj/xcshareddata/xcschemes/ReactiveStreams.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"


### PR DESCRIPTION
- makes the subscription available more easily (clearly)
- additionally, add an other overload of `subscribe:` with a notification handler that explicitly
   takes a `Subscription` parameter.