### PR TITLE
reset a stream's number of requested events in some situations

### DIFF
--- a/Sources/ReactiveStreams/stream-substream.swift
+++ b/Sources/ReactiveStreams/stream-substream.swift
@@ -39,6 +39,13 @@ open class SubStream<Value>: EventStream<Value>
     super.finalizeStream()
   }
 
+  override open func lastSubscriptionWasCanceled()
+  {
+    super.lastSubscriptionWasCanceled()
+    let subscription = sub.load()
+    subscription?.requestNone()
+  }
+
   override open func processAdditionalRequest(_ additional: Int64)
   {
     super.processAdditionalRequest(additional)

--- a/Sources/ReactiveStreams/subscription.swift
+++ b/Sources/ReactiveStreams/subscription.swift
@@ -67,6 +67,18 @@ final public class Subscription
     source.updateRequest(updated)
   }
 
+  // If a subscriber must reduce the number of events it needs to receive,
+  // reduce it to zero first, then raise again. This does carry the risk
+  // of dropped events.
+
+  public func requestNone()
+  {
+    var current = CAtomicsLoad(requested, .relaxed)
+    repeat {
+      if current < 1 { return }
+    } while !CAtomicsCompareAndExchange(requested, &current, 0, .weak, .relaxed, .relaxed)
+  }
+
   // called by our subscriber
 
   public func cancel()

--- a/Tests/ReactiveStreamsTests/XCTestManifests.swift
+++ b/Tests/ReactiveStreamsTests/XCTestManifests.swift
@@ -145,6 +145,7 @@ extension streamTests {
         ("testPaused2", testPaused2),
         ("testPaused3", testPaused3),
         ("testRequested", testRequested),
+        ("testRequestedReset", testRequestedReset),
         ("testSkipN", testSkipN),
         ("testSplit0", testSplit0),
         ("testSplit1", testSplit1),

--- a/Tests/ReactiveStreamsTests/mergeTests.swift
+++ b/Tests/ReactiveStreamsTests/mergeTests.swift
@@ -72,9 +72,6 @@ class mergeTests: XCTestCase
     // therefore event count will be zero
     merged.close()
 
-    let e2 = expectation(description: "posting ends")
-    s.onCompletion { e2.fulfill() }
-
     for i in 0..<count { s.post(i+1) }
     s.close()
 
@@ -134,9 +131,6 @@ class mergeTests: XCTestCase
         e1.fulfill()
       }
     }
-
-    let e2 = expectation(description: "posting ends")
-    s.onCompletion { e2.fulfill() }
 
     s.post(0)
     t.post(TestError(id))

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -117,6 +117,27 @@ class streamTests: XCTestCase
     next.close()
   }
 
+  func testRequestedReset()
+  {
+    let queue = DispatchQueue(label: #function, qos: .utility)
+
+    var subscription: Subscription? = nil
+    let stream = OnRequestStream(queue: queue)
+    let e = expectation(description: #function)
+    stream.subscribe(
+      subscriber: queue,
+      subscriptionHandler: { subscription = $0 },
+      notificationHandler: {
+        (subscriber, subscription, event) in
+        subscription.requestNone()
+        e.fulfill()
+      }
+    )
+
+    subscription!.request(100)
+    waitForExpectations(timeout: 1.0)
+  }
+
   class SelfTerminatingPostBox<Value>: PostBox<Value>
   {
     override func lastSubscriptionWasCanceled()


### PR DESCRIPTION
- when the subscriber count goes to zero, no event needs to be produced anymore
- when no current subscriber requests a notification, the requested event count has gone to zero.