### PR TITLE
test tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Xcode/stream.xcodeproj/xcuserdata
 Package.pins
 Package.resolved
 /ReactiveStreams.xcodeproj
+/.swift-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       osx_image: xcode10.2
       env: SWIFT=5.0.1
 
+    - os: osx
+      osx_image: xcode11
+      env: SWIFT=5.1
+
     - os: linux
       dist: xenial
       language: generic
@@ -18,7 +22,7 @@ matrix:
     - os: linux
       dist: xenial
       language: generic
-      env: SWIFT=5.0.1
+      env: SWIFT=5.0.2
 
 before_install:
   - clang --version

--- a/Tests/ReactiveStreamsTests/streamTests.swift
+++ b/Tests/ReactiveStreamsTests/streamTests.swift
@@ -471,17 +471,17 @@ class streamTests: XCTestCase
 
     XCTAssertEqual(stream.requested, 2)
     XCTAssertEqual(split.0.requested, 3)
-    XCTAssertEqual(split.1.requested, 0)
+    XCTAssertEqual(split.1.requested, 0, String(#line))
 
     stream.post(0)
     let ne = expectation(description: "second value")
     stream.next(count: 1).onValue { _ in ne.fulfill() }
     stream.post(1)
     waitForExpectations(timeout: 1.0)
-    XCTAssertEqual(stream.requested, 0)
+    XCTAssertEqual(stream.requested, 0, String(#line))
 
     split.1.next(count: 5).onEvent { _ in }
-    XCTAssertEqual(stream.requested, 0)
+    XCTAssertEqual(stream.requested, 0, String(#line))
   }
 
   func testPaused1()


### PR DESCRIPTION
- `streamTests.testSplit5` failed on CI, after hundreds of successful runs.
- added some extra output to add context if it happens again
- could not reproduce in over 10000 runs on my machine